### PR TITLE
fix: fixed type for LastSeen in cluster health struct

### DIFF
--- a/cloud-api-openapi-v1.0.0.json
+++ b/cloud-api-openapi-v1.0.0.json
@@ -1001,7 +1001,6 @@
                         },
                         "properties": {
                             "last_seen": {
-                                "format": "date-time",
                                 "type": "string"
                             },
                             "running_operation": {

--- a/types.gen.go
+++ b/types.gen.go
@@ -251,7 +251,7 @@ type Cluster struct {
 	GcAvailable   *bool          `json:"gc_available,omitempty"`
 	HardwareSpecs *HardwareSpecs `json:"hardware_specs"`
 	Health        *struct {
-		LastSeen *time.Time `json:"last_seen,omitempty"`
+		LastSeen *string `json:"last_seen,omitempty"`
 
 		// RunningOperation The type of the currently running operation. Returns an empty string if there is no operation in progress.
 		RunningOperation *ClusterHealthRunningOperation `json:"running_operation,omitempty"`


### PR DESCRIPTION
What the API returns is not a proper timestamp for the LastSeen field in Cluster.Health so removed the type field from the OpenAPI spec.

![image](https://github.com/user-attachments/assets/11d486c9-f334-4bed-80e5-3ee9e40e86a9)
